### PR TITLE
Proof of Concept implementation of Assumes annotation to indicate implicit assumptions of tests

### DIFF
--- a/assumes/.gitignore
+++ b/assumes/.gitignore
@@ -1,0 +1,8 @@
+.project
+.classpath
+.settings
+*.iml
+*.ipr
+*.iws
+target/
+

--- a/assumes/HEADER.txt
+++ b/assumes/HEADER.txt
@@ -1,0 +1,14 @@
+/*
+ * The copyright holders of this work license this file to You under
+ * the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.  You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/assumes/LICENSE
+++ b/assumes/LICENSE
@@ -1,0 +1,264 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+APACHE JACKRABBIT SUBCOMPONENTS
+
+Apache Jackrabbit includes parts with separate copyright notices and license
+terms. Your use of these subcomponents is subject to the terms and conditions
+of the following licenses:
+
+    XPath 2.0/XQuery 1.0 Parser:
+    http://www.w3.org/2002/11/xquery-xpath-applets/xgrammar.zip
+
+    Copyright (C) 2002 World Wide Web Consortium, (Massachusetts Institute of
+    Technology, European Research Consortium for Informatics and Mathematics,
+    Keio University). All Rights Reserved.
+
+    This work is distributed under the W3C(R) Software License in the hope
+    that it will be useful, but WITHOUT ANY WARRANTY; without even the
+    implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    W3C(R) SOFTWARE NOTICE AND LICENSE
+    http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231
+
+    This work (and included software, documentation such as READMEs, or
+    other related items) is being provided by the copyright holders under
+    the following license. By obtaining, using and/or copying this work,
+    you (the licensee) agree that you have read, understood, and will comply
+    with the following terms and conditions.
+
+    Permission to copy, modify, and distribute this software and its
+    documentation, with or without modification, for any purpose and
+    without fee or royalty is hereby granted, provided that you include
+    the following on ALL copies of the software and documentation or
+    portions thereof, including modifications:
+
+       1. The full text of this NOTICE in a location viewable to users
+          of the redistributed or derivative work.
+
+       2. Any pre-existing intellectual property disclaimers, notices,
+          or terms and conditions. If none exist, the W3C Software Short
+          Notice should be included (hypertext is preferred, text is
+          permitted) within the body of any redistributed or derivative code.
+
+       3. Notice of any changes or modifications to the files, including
+          the date changes were made. (We recommend you provide URIs to the
+          location from which the code is derived.)
+
+    THIS SOFTWARE AND DOCUMENTATION IS PROVIDED "AS IS," AND COPYRIGHT
+    HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED,
+    INCLUDING BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY OR FITNESS
+    FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE OR
+    DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS,
+    TRADEMARKS OR OTHER RIGHTS.
+
+    COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL
+    OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE SOFTWARE OR
+    DOCUMENTATION.
+
+    The name and trademarks of copyright holders may NOT be used in
+    advertising or publicity pertaining to the software without specific,
+    written prior permission. Title to copyright in this software and
+    any associated documentation will at all times remain with
+    copyright holders.

--- a/assumes/NOTICE
+++ b/assumes/NOTICE
@@ -1,0 +1,10 @@
+   =========================================================================
+   ==  NOTICE file corresponding to the section 4 d of                    ==
+   ==  the Apache License, Version 2.0,                                   ==
+   ==  in this case for junit.contrib Assumes        .                    ==
+   =========================================================================
+
+junit.contrib Assumes
+Copyright 2011 stephenc at apache
+
+

--- a/assumes/README.txt
+++ b/assumes/README.txt
@@ -1,0 +1,101 @@
+=====================================
+Welcome to JUnit Contrib Assumes
+=====================================
+
+Consider the case where you are testing a List class...
+
+we have
+
+public class MyListTest {
+
+ @Test
+ public void newListIsEmpty() {
+   assertThat(new MyList().isEmpty(), is(true);
+ }
+
+ @Test
+ public void newListHasSizeZero() {
+   assertThat(new MyList().size(), is(0));
+ }
+
+ @Test
+ public void addPutsAnElementIntoAnEmptyList() {
+   MyList l = new MyList();
+   l.add(new Object());
+   assertThat(l.isEmpty(), is(false));
+ }
+
+ @Test
+ public void addIncreasesSizeOfPopulatedListByOne() {
+   MyList l = new MyList();
+   l.add(new Object());
+   int s = l.size();
+   l.add(new Object());
+   assertThat(l.size(), is(s + 1));
+ }
+
+}
+
+We now want to add some tests of the delete functionality... but the
+reality is that until/unless some of the preceding tests are passing,
+the tests for delete are meaningless. We could have a perfectly
+functional MyList.delete() method but until such time as the above tests
+are passing, there is no way to tell that the method does not work.
+
+Now I could code my tests like such
+
+ @Test
+ public void deleteIsANoOpOnEmptyList() {
+   MyList l = new MyList();
+   assumeThat(l.isEmpty(), is(true));
+   l.delete(new Object());
+ }
+
+But all that I am doing is repeating code from the preceding tests,
+having changed all those tests' assertThat(...)s into assumeThat(...)s
+
+That does not seem agile to me, copy & paste & search & replace... bad
+code smell there
+
+I would much rather be able to annotate the tests with an @Assumes
+annotation that indicates that the test assumes that the specified
+tests are passing, e.g.
+
+ @Test
+ @Assumes("newListIsEmpty")
+ public void deleteIsANoOpOnEmptyList() {
+   MyList l = new MyList();
+   l.delete(new Object());
+ }
+
+ @Test
+ @Assumes({"newListIsEmpty","addPutsAnElementIntoAnEmptyList")
+ public void deleteRemovesAnElement() {
+   MyList l = new MyList();
+   Object o = new Object();
+   l.add(o);
+   l.delete(o);
+   assertThat(l.isEmpty(), is(true));
+ }
+
+In fact in my initial example of tests, there are some additional
+assumptions that I didn't make explicit
+
+ @Test
+ @Assumes("newListIsEmpty")
+ public void addPutsAnElementIntoAnEmptyList() {
+   ...
+ }
+
+and
+
+ @Test
+ @Assumes({"newListIsEmpty","addPutsAnElementIntoAnEmptyList")
+ public void addIncreasesSizeOfPopulatedListByOne() {
+   ...
+ }
+
+This module allows this functionality by providing the Corollaries runner
+which is aware of Assumes declared by tests and will ensure that the tests
+of known invalid assumptions are skipped.
+

--- a/assumes/pom.xml
+++ b/assumes/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ The copyright holders of this work license this file to You under 
+ the Apache License, Version 2.0 (the "License"); you may not use this 
+ file except in compliance with the License.  You may obtain a copy of 
+ the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.junit.contrib</groupId>
+  <artifactId>junit-assumes</artifactId>
+  <version>0.1-SNAPSHOT</version>
+
+  <name>JUnit Assumes</name>
+  <description>Allows tests to declare implicit assumptions of other tests passing, if an assuption is false the test gets skipped</description>
+  <inceptionYear>2011</inceptionYear>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>stephenc</id>
+      <name>Stephen Connolly</name>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <properties>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.9</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>${basedir}</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE</include>
+          <include>NOTICE</include>
+        </includes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.8.1</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/assumes/src/main/java/org/junit/contrib/assumes/Assumes.java
+++ b/assumes/src/main/java/org/junit/contrib/assumes/Assumes.java
@@ -1,0 +1,34 @@
+/*
+ * The copyright holders of this work license this file to You under
+ * the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.  You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.junit.contrib.assumes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Identifies the implicit assumptions of a test. If any of the implicit assumptions of a test are known to be untrue
+ * or are known to be unknown (i.e. those tests failed, threw an error, or were skipped) then the annotated test
+ * will be skipped.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Inherited
+public @interface Assumes {
+    public String[] value();
+}

--- a/assumes/src/main/java/org/junit/contrib/assumes/Corollaries.java
+++ b/assumes/src/main/java/org/junit/contrib/assumes/Corollaries.java
@@ -1,0 +1,253 @@
+package org.junit.contrib.assumes;
+
+import org.junit.Ignore;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.manipulation.Sorter;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runner.notification.StoppedByUserException;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerScheduler;
+import org.junit.runners.model.Statement;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A runner which is aware of the {@link Assumes} of its {@link org.junit.Test}s
+ */
+public class Corollaries extends BlockJUnit4ClassRunner {
+
+    private Sorter fSorter= Sorter.NULL;
+
+    private List<FrameworkMethod> fFilteredChildren;
+
+    private RunnerScheduler fScheduler= new RunnerScheduler() {
+        public void schedule(Runnable childStatement) {
+            childStatement.run();
+        }
+
+        public void finished() {
+            // do nothing
+        }
+    };
+
+    /**
+     * Creates a BlockJUnit4ClassRunner to run {@code klass}
+     *
+     * @throws org.junit.runners.model.InitializationError
+     *          if the test class is malformed.
+     */
+    public Corollaries(Class<?> klass) throws InitializationError {
+        super(klass);
+    }
+
+    @Override
+    public void sort(Sorter sorter) {
+        fSorter= sorter;
+        for (FrameworkMethod each : getFilteredChildren())
+            sortChild(each);
+        Collections.sort(getFilteredChildren(), comparator());
+        assumptionSort(getFilteredChildren());
+    }
+
+    private void sortChild(FrameworkMethod child) {
+        fSorter.apply(child);
+    }
+
+    private Comparator<? super FrameworkMethod> comparator() {
+        return new Comparator<FrameworkMethod>() {
+            public int compare(FrameworkMethod o1, FrameworkMethod o2) {
+                return fSorter.compare(describeChild(o1), describeChild(o2));
+            }
+        };
+    }
+
+    @Override
+    public void run(final RunNotifier notifier) {
+        EachTestNotifier testNotifier= new EachTestNotifier(notifier, getDescription());
+        try {
+            Statement statement= classBlock(notifier);
+            statement.evaluate();
+        } catch (AssumptionViolatedException e) {
+            testNotifier.fireTestIgnored();
+        } catch (StoppedByUserException e) {
+            throw e;
+        } catch (Throwable e) {
+            testNotifier.addFailure(e);
+        }
+    }
+    /**
+     * Returns a {@link Statement}: Call {@link #runChild(Object, RunNotifier)}
+     * on each object returned by {@link #getChildren()} (subject to any imposed
+     * filter and sort)
+     */
+    protected Statement childrenInvoker(final RunNotifier notifier) {
+        return new Statement() {
+            @Override
+            public void evaluate() {
+                runChildren(notifier, Collections.synchronizedSet(new HashSet<String>()));
+            }
+        };
+    }
+
+    private void runChildren(final RunNotifier notifier, final Set<String> invalidAssumptions) {
+        RunListener l = new RunListener() {
+            @Override
+            public void testFailure(Failure failure) throws Exception {
+                invalidAssumptions.add(failure.getDescription().getMethodName());
+            }
+
+            @Override
+            public void testAssumptionFailure(Failure failure) {
+                invalidAssumptions.add(failure.getDescription().getMethodName());
+            }
+
+            @Override
+            public void testIgnored(Description description) throws Exception {
+                invalidAssumptions.add(description.getMethodName());
+            }
+        };
+        notifier.addListener(l);
+        for (final FrameworkMethod each : getFilteredChildren())
+             fScheduler.schedule(new Runnable() {
+                public void run() {
+                    Corollaries.this.runChild(each, notifier, invalidAssumptions);
+                }
+            });
+        fScheduler.finished();
+    }
+
+    protected void runChild(final FrameworkMethod method, RunNotifier notifier, Set<String> invalidAssumptions) {
+        Assumes assumptions = method.getAnnotation(Assumes.class);
+        boolean invalidAssumption = false;
+        if (assumptions != null) {
+            for (String assumption: assumptions.value()) {
+                if (invalidAssumptions.contains(assumption)) {
+                    invalidAssumption = true;
+                    break;
+                }
+            }
+        }
+        if (invalidAssumption) {
+            invalidAssumptions.add(method.getName());
+            notifier.fireTestIgnored(describeChild(method));
+        } else {
+            runChild(method, notifier);
+        }
+    }
+
+    @Override
+    protected final void runChild(FrameworkMethod method, RunNotifier notifier) {
+        super.runChild(method, notifier);
+    }
+
+    private List<FrameworkMethod> getFilteredChildren() {
+        if (fFilteredChildren == null) {
+            fFilteredChildren = new ArrayList<FrameworkMethod>(getChildren());
+            assumptionSort(fFilteredChildren);
+        }
+        return fFilteredChildren;
+    }
+
+    private void assumptionSort(List<FrameworkMethod> methods) {
+        int size = methods.size();
+        for (int i = 0; i < size; i++) {
+            FrameworkMethod m = methods.get(i);
+            Assumes assumes = m.getAnnotation(Assumes.class);
+            if (assumes != null) {
+                Set<String> assumptions = new HashSet<String>(Arrays.asList(assumes.value()));
+                for (int j = size - 1; j > i; j--) {
+                    if (assumptions.contains(methods.get(j).getName())) {
+                        methods.add(j, methods.remove(i));
+                        break;
+                    }
+                }
+            }
+        }
+        Collections.sort(getFilteredChildren(), new AssumptionComparator());
+    }
+
+    @Override
+    public Description getDescription() {
+        Description description= Description.createSuiteDescription(getName(),
+                getTestClass().getAnnotations());
+        for (FrameworkMethod child : getFilteredChildren())
+            description.addChild(describeChild(child));
+        return description;
+    }
+
+    public void filter(Filter filter) throws NoTestsRemainException {
+        for (Iterator<FrameworkMethod> iter = getFilteredChildren().iterator(); iter.hasNext(); ) {
+            FrameworkMethod each = iter.next();
+            if (shouldRun(filter, each))
+                try {
+                    filter.apply(each);
+                } catch (NoTestsRemainException e) {
+                    iter.remove();
+                }
+            else
+                iter.remove();
+        }
+        if (getFilteredChildren().isEmpty()) {
+            throw new NoTestsRemainException();
+        }
+    }
+
+    private boolean shouldRun(Filter filter, FrameworkMethod each) {
+        return filter.shouldRun(describeChild(each));
+    }
+
+    /**
+     * Sets a scheduler that determines the order and parallelization
+     * of children.  Highly experimental feature that may change.
+     */
+    public void setScheduler(RunnerScheduler scheduler) {
+        this.fScheduler = scheduler;
+    }
+
+    private class AssumptionComparator implements Comparator<FrameworkMethod> {
+
+        public int compare(FrameworkMethod o1, FrameworkMethod o2) {
+            if (assumed(o2.getAnnotation(Assumes.class), o1.getName())) {
+                if (!assumed(o1.getAnnotation(Assumes.class), o2.getName())) {
+                    return -1;
+                }
+            } else {
+                if (assumed(o1.getAnnotation(Assumes.class), o2.getName())) {
+                    return 1;
+                }
+            }
+            return 0;
+        }
+
+        private boolean assumed(Assumes assumes, String predicate) {
+            if (assumes == null) {
+                return false;
+            }
+            for (String s : assumes.value()) {
+                if (s.equals(predicate)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    }
+
+}

--- a/assumes/src/test/java/org/junit/contrib/assumes/AssumesTest.java
+++ b/assumes/src/test/java/org/junit/contrib/assumes/AssumesTest.java
@@ -1,6 +1,22 @@
+/*
+ * The copyright holders of this work license this file to You under
+ * the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.  You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.junit.contrib.assumes;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.Description;
@@ -8,11 +24,13 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
+import org.junit.runner.manipulation.Filter;
 
 import java.util.Comparator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
 
 @RunWith(Enclosed.class)
 public class AssumesTest {
@@ -64,15 +82,18 @@ public class AssumesTest {
             public void a() {
                 log += "a";
             }
+
             @Test
             public void b() {
                 log += "b";
             }
+
             @Test
             public void c() {
                 log += "c";
                 assertThat(true, is(false));
             }
+
             @Test
             public void d() {
                 log += "d";
@@ -111,15 +132,18 @@ public class AssumesTest {
             public void a() {
                 log += "a";
             }
+
             @Test
             public void b() {
                 log += "b";
             }
+
             @Test
             public void c() {
                 log += "c";
                 assertThat(true, is(false));
             }
+
             @Test
             public void d() {
                 log += "d";
@@ -159,15 +183,18 @@ public class AssumesTest {
             public void a() {
                 log += "a";
             }
+
             @Test
             @Assumes("c")
             public void b() {
                 log += "b";
             }
+
             @Test
             public void c() {
                 log += "c";
             }
+
             @Test
             public void d() {
                 log += "d";
@@ -193,14 +220,17 @@ public class AssumesTest {
             @Test
             public void a() {
             }
+
             @Test
             @Assumes("c")
             public void b() {
             }
+
             @Test
             @Assumes("d")
             public void c() {
             }
+
             @Test
             @Assumes("b")
             public void d() {
@@ -226,14 +256,17 @@ public class AssumesTest {
             @Test
             public void a() {
             }
+
             @Test
             @Assumes("c")
             public void b() {
             }
+
             @Test
             @Assumes("b")
             public void c() {
             }
+
             @Test
             public void d() {
             }
@@ -272,16 +305,195 @@ public class AssumesTest {
             public void a() {
                 log += "a";
             }
+
             @Test
             @Assumes("c")
             public void b() {
                 log += "b";
             }
+
             @Test
             public void c() {
                 log += "c";
                 assertThat(true, is(false));
             }
+
+            @Test
+            public void d() {
+                log += "d";
+            }
+        }
+    }
+
+    public static class UntestedAssumptionsAreAssumedTrue {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward()).filterWith(new Filter() {
+                @Override
+                public boolean shouldRun(Description description) {
+                    return !"c".equals(description.getMethodName());
+                }
+
+                @Override
+                public String describe() {
+                    return "Anything but c";
+                }
+            });
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("abd"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward()).filterWith(new Filter() {
+                @Override
+                public boolean shouldRun(Description description) {
+                    return !"c".equals(description.getMethodName());
+                }
+
+                @Override
+                public String describe() {
+                    return "Anything but c";
+                }
+            });
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("dba"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+            }
+
+            @Test
+            public void c() {
+                log += "c";
+                assertThat(true, is(false));
+            }
+
+            @Test
+            public void d() {
+                log += "d";
+            }
+        }
+    }
+
+    public static class IgnoredAssumptionsAreSkipped {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("ad"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(2));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("da"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(2));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+            }
+
+            @Test
+            @Ignore("for now")
+            public void c() {
+                log += "c";
+            }
+
+            @Test
+            public void d() {
+                log += "d";
+            }
+        }
+    }
+
+    public static class UntestedAssumptionsAreSkipped {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("acd"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(1));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("dca"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(1));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+            }
+
+            @Test
+            public void c() {
+                log += "c";
+                assumeThat(true, is(false));
+            }
+
             @Test
             public void d() {
                 log += "d";
@@ -321,46 +533,56 @@ public class AssumesTest {
             public void a() {
                 log += "a";
             }
+
             @Test
             @Assumes("c")
             public void b() {
                 log += "b";
             }
+
             @Test
             public void c() {
                 log += "c";
             }
+
             @Test
-            @Assumes({"k","h"})
+            @Assumes({"k", "h"})
             public void d() {
                 log += "d";
             }
+
             @Test
             public void e() {
                 log += "e";
             }
+
             @Test
             @Assumes("c")
             public void f() {
                 log += "f";
             }
+
             @Test
             public void g() {
                 log += "g";
             }
+
             @Test
-            @Assumes({"c","b"})
+            @Assumes({"c", "b"})
             public void h() {
                 log += "h";
             }
+
             @Test
             public void i() {
                 log += "i";
             }
+
             @Test
             public void j() {
                 log += "j";
             }
+
             @Test
             public void k() {
                 log += "k";
@@ -400,47 +622,57 @@ public class AssumesTest {
             public void a() {
                 log += "a";
             }
+
             @Test
             @Assumes("c")
             public void b() {
                 log += "b";
             }
+
             @Test
             public void c() {
                 log += "c";
                 assertThat(true, is(false));
             }
+
             @Test
-            @Assumes({"k","h"})
+            @Assumes({"k", "h"})
             public void d() {
                 log += "d";
             }
+
             @Test
             public void e() {
                 log += "e";
             }
+
             @Test
             @Assumes("c")
             public void f() {
                 log += "f";
             }
+
             @Test
             public void g() {
                 log += "g";
             }
+
             @Test
-            @Assumes({"c","b"})
+            @Assumes({"c", "b"})
             public void h() {
                 log += "h";
             }
+
             @Test
             public void i() {
                 log += "i";
             }
+
             @Test
             public void j() {
                 log += "j";
             }
+
             @Test
             public void k() {
                 log += "k";
@@ -480,47 +712,57 @@ public class AssumesTest {
             public void a() {
                 log += "a";
             }
+
             @Test
             @Assumes("c")
             public void b() {
                 log += "b";
                 assertThat(true, is(false));
             }
+
             @Test
             public void c() {
                 log += "c";
             }
+
             @Test
-            @Assumes({"k","h"})
+            @Assumes({"k", "h"})
             public void d() {
                 log += "d";
             }
+
             @Test
             public void e() {
                 log += "e";
             }
+
             @Test
             @Assumes("c")
             public void f() {
                 log += "f";
             }
+
             @Test
             public void g() {
                 log += "g";
             }
+
             @Test
-            @Assumes({"c","b"})
+            @Assumes({"c", "b"})
             public void h() {
                 log += "h";
             }
+
             @Test
             public void i() {
                 log += "i";
             }
+
             @Test
             public void j() {
                 log += "j";
             }
+
             @Test
             public void k() {
                 log += "k";

--- a/assumes/src/test/java/org/junit/contrib/assumes/AssumesTest.java
+++ b/assumes/src/test/java/org/junit/contrib/assumes/AssumesTest.java
@@ -1,0 +1,530 @@
+package org.junit.contrib.assumes;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+
+import java.util.Comparator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Enclosed.class)
+public class AssumesTest {
+    private static Comparator<Description> forward() {
+        return new Comparator<Description>() {
+            public int compare(Description o1, Description o2) {
+                return o1.getDisplayName().compareTo(o2.getDisplayName());
+            }
+        };
+    }
+
+    private static Comparator<Description> backward() {
+        return new Comparator<Description>() {
+            public int compare(Description o1, Description o2) {
+                return o2.getDisplayName().compareTo(o1.getDisplayName());
+            }
+        };
+    }
+
+    public static class NoAssumesImpliesNoAffectsOnOrder {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("abcd"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("dcba"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+            @Test
+            public void b() {
+                log += "b";
+            }
+            @Test
+            public void c() {
+                log += "c";
+                assertThat(true, is(false));
+            }
+            @Test
+            public void d() {
+                log += "d";
+            }
+        }
+    }
+
+    public static class AssumesDoesNotAffectStandardRunner {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("abcd"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("dcba"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+            @Test
+            public void b() {
+                log += "b";
+            }
+            @Test
+            public void c() {
+                log += "c";
+                assertThat(true, is(false));
+            }
+            @Test
+            public void d() {
+                log += "d";
+            }
+        }
+    }
+
+    public static class AssumesRestrictsOrdering {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("acbd"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("dcba"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+            }
+            @Test
+            public void c() {
+                log += "c";
+            }
+            @Test
+            public void d() {
+                log += "d";
+            }
+        }
+    }
+
+    public static class LongCircularAssumptions {
+        @Test
+        public void doesNotInfiniteLoopInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            new JUnitCore().run(request);
+        }
+
+        @Test
+        public void doesNotInfiniteLoopInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            new JUnitCore().run(request);
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+            }
+            @Test
+            @Assumes("c")
+            public void b() {
+            }
+            @Test
+            @Assumes("d")
+            public void c() {
+            }
+            @Test
+            @Assumes("b")
+            public void d() {
+            }
+        }
+    }
+
+    public static class ShortCircularAssumptions {
+        @Test
+        public void doesNotInfiniteLoopInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            new JUnitCore().run(request);
+        }
+
+        @Test
+        public void doesNotInfiniteLoopInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            new JUnitCore().run(request);
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+            }
+            @Test
+            @Assumes("c")
+            public void b() {
+            }
+            @Test
+            @Assumes("b")
+            public void c() {
+            }
+            @Test
+            public void d() {
+            }
+        }
+    }
+
+    public static class FailedAssumptionsAreSkipped {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("acd"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(1));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("dca"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(1));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+            }
+            @Test
+            public void c() {
+                log += "c";
+                assertThat(true, is(false));
+            }
+            @Test
+            public void d() {
+                log += "d";
+            }
+        }
+    }
+
+    public static class ComplexSequenceSmokeTest {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("acbefghijkd"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("kjigecfbhda"));
+            assertThat(result.getFailureCount(), is(0));
+            assertThat(result.getIgnoreCount(), is(0));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+            }
+            @Test
+            public void c() {
+                log += "c";
+            }
+            @Test
+            @Assumes({"k","h"})
+            public void d() {
+                log += "d";
+            }
+            @Test
+            public void e() {
+                log += "e";
+            }
+            @Test
+            @Assumes("c")
+            public void f() {
+                log += "f";
+            }
+            @Test
+            public void g() {
+                log += "g";
+            }
+            @Test
+            @Assumes({"c","b"})
+            public void h() {
+                log += "h";
+            }
+            @Test
+            public void i() {
+                log += "i";
+            }
+            @Test
+            public void j() {
+                log += "j";
+            }
+            @Test
+            public void k() {
+                log += "k";
+            }
+        }
+    }
+
+    public static class ComplexLargeSmokeTest {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("acegijk"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(4));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("kjigeca"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(4));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+            }
+            @Test
+            public void c() {
+                log += "c";
+                assertThat(true, is(false));
+            }
+            @Test
+            @Assumes({"k","h"})
+            public void d() {
+                log += "d";
+            }
+            @Test
+            public void e() {
+                log += "e";
+            }
+            @Test
+            @Assumes("c")
+            public void f() {
+                log += "f";
+            }
+            @Test
+            public void g() {
+                log += "g";
+            }
+            @Test
+            @Assumes({"c","b"})
+            public void h() {
+                log += "h";
+            }
+            @Test
+            public void i() {
+                log += "i";
+            }
+            @Test
+            public void j() {
+                log += "j";
+            }
+            @Test
+            public void k() {
+                log += "k";
+            }
+        }
+    }
+
+    public static class ComplexSmallEffectSmokeTest {
+        private static String log;
+
+        @Before
+        public void setUp() {
+            log = "";
+        }
+
+        @Test
+        public void runsInOrder() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(forward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("acbefgijk"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(2));
+        }
+
+        @Test
+        public void runsInReverse() throws Exception {
+            Request request = Request.classes(Artifact.class).sortWith(backward());
+            Result result = new JUnitCore().run(request);
+            assertThat(log, is("kjigecfba"));
+            assertThat(result.getFailureCount(), is(1));
+            assertThat(result.getIgnoreCount(), is(2));
+        }
+
+        @RunWith(Corollaries.class)
+        public static class Artifact {
+            @Test
+            public void a() {
+                log += "a";
+            }
+            @Test
+            @Assumes("c")
+            public void b() {
+                log += "b";
+                assertThat(true, is(false));
+            }
+            @Test
+            public void c() {
+                log += "c";
+            }
+            @Test
+            @Assumes({"k","h"})
+            public void d() {
+                log += "d";
+            }
+            @Test
+            public void e() {
+                log += "e";
+            }
+            @Test
+            @Assumes("c")
+            public void f() {
+                log += "f";
+            }
+            @Test
+            public void g() {
+                log += "g";
+            }
+            @Test
+            @Assumes({"c","b"})
+            public void h() {
+                log += "h";
+            }
+            @Test
+            public void i() {
+                log += "i";
+            }
+            @Test
+            public void j() {
+                log += "j";
+            }
+            @Test
+            public void k() {
+                log += "k";
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Sorting could probably be improved somewhat
- A circular assumption will have somewhat undefined ordering, would be better to bomb out the circular assumption with an error
- Had to copy a bit too much from ParentRunner, possibly indicating the lack of a suitable extension point in ParentRunner to support this use case.
- Cobertura reports 86% line coverage and 96% branch coverage. While the untested code is the Copy and Paste from ParentRunner, more tests, especially around ordering, would be good.
